### PR TITLE
Added Scrollbar & Checkbox option to mod config, window is also adjustable now

### DIFF
--- a/ui/database.py
+++ b/ui/database.py
@@ -136,6 +136,13 @@ class ModConfigVar:
                     v=True
                 else:
                     v=False
+            elif type_name.startswith("toggle"): 
+                self.type="toggle"
+                # Be generous on boolean values. 
+                if str(val).strip().lower() in [1,-1,'1','-1','t','y','true','yes','on']:
+                    v = var.max
+                else:
+                    v = var.min
         except:
             return None
 
@@ -149,8 +156,10 @@ class ModConfigVar:
 
         self.min:float=float(min) if min else None
         self.max:float=float(max) if max else None
+        self.min:toggle=str(min) if min else None
+        self.max:toggle=str(max) if max else None
         self.size:int=int(size) if size else None
-        self.default:str=self._cleanValue(default)
+        self.default:str=str(default) if default else None
         self.value:str=self._cleanValue(value)
         if self.value is None:
             self.value = value = self.default


### PR DESCRIPTION
Fixes #27
adds scrollable frame and checkbox

in spacehaven-modloader.py -> added class ScrollableFrame and tweaked modConfigFrame accordingly. added checkbox to create_ModConfigVariableEntry -> added modList.configure(exportselection=False) because my new scrollable frame was causing the listbox to lose focus and lose it's selection - this fixed that and did not cause any issues.

in database.py -> added "toggle" type to _cleanValue. Also added min and max :toggle to loadXml since the rest were there, although it worked without it -> changed self.default:str=self._cleanValue(value) to self.default:str=str(default) -> no change in any function I was able to test but fixed issues with var.default not giving the correct value in certain situations (returning none, etc.)

Use my checkbox_test mod for checkbox example!
Use spacehaven+ to see the scrollbar in action!

https://github.com/ximerous/spacehaven-modloader/blob/develop/mods/test_mods.zip

--- no known issues ---