### PR TITLE
Fix three macOS-specific bugs

### DIFF
--- a/loader/assets/annotate.py
+++ b/loader/assets/annotate.py
@@ -259,13 +259,13 @@ def annotate(corePath):
         languages = fragment.find("languages")
         if languages is not None:
             for lang in languages.findall("l"):
-                lang = lang.get("lang")
+                lang_code = lang.get("lang")
                 f = lang.find("file")
                 if f is not None:
                     fid = f.get("fid")
-                    if fid is not None and gfilename[fid] is not None:
+                    if fid is not None and gfilename.get(fid) is not None:
                         lang.set("_annotation", gfilename[fid])
-                        if lang == "EN":
+                        if lang_code == "EN":
                             fragment.set("_annotation", gfilename[fid])
 
     annotatedHavenPath = os.path.join(corePath, "library", "haven_annotated.xml")

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -350,6 +350,7 @@ class Window(Frame):
                 steam_path = Path(Path.home(), ".steam", "steam")
             if platform.system() == "Darwin":
                 steam_path = Path(Path.home(), "Library", "Application Support", "Steam")
+                game_executable += ".app"
 
             libraryfolders_vdf = vdf.parse(open(str(Path(steam_path, "steamapps", "libraryfolders.vdf"))))["libraryfolders"]
             for key in libraryfolders_vdf:

--- a/ui/launcher.py
+++ b/ui/launcher.py
@@ -27,6 +27,10 @@ def open(path):
     if sys.platform == "win32":
         os.startfile(path)
     elif sys.platform == "darwin":
-        subprocess.call(["open", path])
+        # Can't use `open path` when path is inside a .app bundle — macOS
+        # resolves up to the .app and launches the game instead of the folder.
+        # AppleScript's `reveal` navigates inside bundles correctly.
+        subprocess.call(["osascript", "-e", f'tell application "Finder" to reveal POSIX file "{path}"'])
+        subprocess.call(["osascript", "-e", 'tell application "Finder" to activate'])
     else:
         subprocess.call(["xdg-open", path])


### PR DESCRIPTION
Three macOS-specific bugs found while running from source for the first time.

**1. Steam autolocator saves wrong path** — `game_executable` never gets `.app` appended on Darwin (Windows gets `.exe`, Mac gets nothing). Saved path fails `os.path.exists()` so user has to browse manually every launch. One-line fix.

**2. Annotate XML crash** — variable shadowing bug in `annotate.py`. `lang` gets overwritten with a string, then `.find("file")` returns an int (Python string method), then `.get()` on the int raises `AttributeError: 'int' object has no attribute 'get'`. Fixed by renaming the string variable to `lang_code`.

**3. Extract Assets / Annotate XML launch the game instead of opening the folder** — `subprocess.call(["open", path])` on macOS, when path is inside a `.app` bundle, resolves up to the app and launches it. Fixed with AppleScript `reveal` which navigates inside bundles correctly.

All tested and confirmed working on macOS.