### PR TITLE
Process XML modifications bundled in JAR mods

### DIFF
--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -22,7 +22,6 @@ import ui.log
 import ui.paths
 import version
 from ui.scrolledlistbox import ScrolledListbox
-from ui.database import JarMod
 
 POSSIBLE_SPACEHAVEN_LOCATIONS = [
     # MacOS
@@ -978,19 +977,13 @@ class Window(Frame):
             messagebox.showerror("Error during quick launch", traceback.format_exc(3))
 
     def patchAndLaunch(self):
-        # activeModPaths = [mod.path for mod in DatabaseHandler.getActiveMods()]
-
         activeMods = DatabaseHandler.getActiveMods()
-        xmlMods = []
 
-        print(activeMods)
-        print(type(activeMods))
-
-        for mod in activeMods:
-            if isinstance(mod, JarMod):
-                continue
-            else:
-                xmlMods.append(mod)
+        # JAR mods are injected into the game through config.json's classPath
+        # (handled in JarMod.enable() during mod discovery), but they can ALSO
+        # ship traditional XML modifications under library/ and patches/ just
+        # like any XML mod. Pass every active mod through the XML pipeline so
+        # those modifications are merged in too.
 
         if getattr(self, "launch_without_saving_config", False):
             ui.log.log("Skipping config autosave because user chose to launch without saving.")
@@ -1002,7 +995,7 @@ class Window(Frame):
                     mod.saveConfig()
 
         try:
-            loader.load.load(self.jarPath, xmlMods, self.current_mods_signature())
+            loader.load.load(self.jarPath, activeMods, self.current_mods_signature())
             ui.launcher.launchAndWait(self.gamePath)
             loader.load.unload(self.jarPath)
         except:

--- a/tests/test_jarmod_xml.py
+++ b/tests/test_jarmod_xml.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import lxml.etree
+
+import loader.assets.merge as merge
+
+
+# Minimal but valid core library files. merge.mods() requires every entry in
+# PATCHABLE_XML_FILES to exist, library/textures to have at least one <re n>,
+# and library/audio to have an <audio> root.
+CORE_FILES = {
+    "haven": "<data><Element><me mid=\"1\"/></Element></data>",
+    "texts": "<t></t>",
+    "animations": "<AllAnimations><animations></animations></AllAnimations>",
+    "textures": (
+        "<AllTexturesAndRegions><textures></textures>"
+        "<regions><re n=\"100\" t=\"0\" x=\"0\" y=\"0\" w=\"1\" h=\"1\"/></regions>"
+        "</AllTexturesAndRegions>"
+    ),
+    "audio": "<audio></audio>",
+}
+
+
+class FakeGameInfo:
+    def __init__(self, jarPath):
+        self.jarPath = str(jarPath)
+        self.version = "1.0.0"
+
+
+class JarModXmlMergeTests(unittest.TestCase):
+    """A JAR mod can ship traditional XML modifications under library/.
+
+    Regression guard for the bug where JAR mods were excluded from the XML
+    merge pipeline and only had their .jar injected via the classPath.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+        self.core_path = self.root / "core"
+        core_library = self.core_path / "library"
+        core_library.mkdir(parents=True)
+        for name, content in CORE_FILES.items():
+            (core_library / name).write_text(content, encoding="utf-8")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _make_jar_mod(self, mod_name, element_mid):
+        """Create a mod folder that contains BOTH a .jar and a library/ XML mod."""
+        mod_path = self.root / "mods" / mod_name
+        (mod_path / "library").mkdir(parents=True)
+        # The presence of a .jar file is what classifies this as a JAR mod.
+        (mod_path / f"{mod_name}.jar").write_text("", encoding="utf-8")
+        (mod_path / "library" / "haven.xml").write_text(
+            "<data><Element><me mid=\"{}\"/></Element></data>".format(element_mid),
+            encoding="utf-8",
+        )
+        return mod_path
+
+    def _read_core_haven(self):
+        return lxml.etree.parse(self.core_path / "library" / "haven")
+
+    def test_jar_mod_library_xml_is_merged(self):
+        mod_path = self._make_jar_mod("XmlCarryingJarMod", element_mid="999")
+
+        merge.mods(str(self.core_path), [], [str(mod_path)])
+
+        merged = self._read_core_haven()
+        self.assertTrue(
+            merged.xpath("/data/Element/me[@mid='999']"),
+            "JAR mod's library/haven.xml definition was not merged into the core library.",
+        )
+        # Core content must be preserved.
+        self.assertTrue(merged.xpath("/data/Element/me[@mid='1']"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A JAR mod can ship traditional XML modifications (under `library/` and `patches/`) just like any XML mod. Currently the mod loader only injects the mod's `.jar` into `config.json`'s `classPath` and **skips its XML content entirely**.

The cause is in `patchAndLaunch()`: JAR mods were explicitly filtered out of the list passed to `loader.load.load()`:

> for mod in activeMods:
>     if isinstance(mod, JarMod):
>         continue          # JAR mods never reached the XML pipeline
>     else:
>         xmlMods.append(mod)
>         
> loader.load.load(self.jarPath, xmlMods, ...)

So a JAR mod's library/haven.xml, patches/, textures and audio were never merged into the game.

Fix
Pass every active mod (including JarMods) through the XML pipeline. The JAR classPath injection is still handled separately in JarMod.enable() during mod discovery, so both paths now coexist:

activeMods = DatabaseHandler.getActiveMods()

loader.load.load(self.jarPath, activeMods, self.current_mods_signature())
The QuickLaunch cache signature already accounts for all active mods (via getActiveMods()), so caching stays correct.

Cleanup
Removed leftover print(activeMods) / print(type(activeMods)) debug statements.
Removed the now-unused from ui.database import JarMod import.
Tests
Added tests/test_jarmod_xml.py: a regression test that builds a mod containing both a .jar and a library/haven.xml, then verifies the XML definition is merged into the core library while existing core content is preserved.

Validation
Built a frozen executable from this branch and confirmed on a real Windows Steam install (play_with_mods) that a JAR mod carrying a library/ XML change now applies that change in-game, with the expected merge lines appearing in mods/modloader/logs.txt