### PR TITLE
Fix loader lingering or force-quitting on macOS Cmd+Q

### DIFF
--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -862,6 +862,12 @@ class Window(Frame):
         self.after(self.background_refresh_delay, self.update_background_state)
 
     def update_background_state(self):
+        # A previously scheduled tick can still fire after the window has
+        # been destroyed (e.g. quit() ran while this callback was pending),
+        # leaving launchButton's underlying Tk widget gone.
+        if not self.winfo_exists():
+            return
+
         extra_label = "." * (self.background_counter % 5)
         self.background_counter += 1
 
@@ -1023,7 +1029,12 @@ def handleException(type, value, trace):
     ui.log.log("!! Exception !!")
     ui.log.log(message)
 
-    messagebox.showerror("Error", "Sorry, something went wrong!\n\n" "Please open an issue at https://github.com/Spacehaven-modding-tools/spacehaven-modloader and attach logs.txt from your mods/modloader/ folder.")
+    try:
+        messagebox.showerror("Error", "Sorry, something went wrong!\n\n" "Please open an issue at https://github.com/Spacehaven-modding-tools/spacehaven-modloader and attach logs.txt from your mods/modloader/ folder.")
+    except TclError:
+        # The window may already be gone (e.g. the error happened in a
+        # callback scheduled before quitting); nothing more we can do.
+        pass
 
 
 if __name__ == "__main__":

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -854,7 +854,10 @@ class Window(Frame):
             finally:
                 self.background_finished = True
 
-        self.background_thread = threading.Thread(target=_wrapper)
+        # daemon=True so the interpreter can still exit if the GUI goes away
+        # while a task (e.g. waiting on the launched game) is blocked; without
+        # it the loader lingers as a headless process (issue #74).
+        self.background_thread = threading.Thread(target=_wrapper, daemon=True)
         self.background_thread.start()
         self.after(self.background_refresh_delay, self.update_background_state)
 
@@ -1048,6 +1051,12 @@ if __name__ == "__main__":
     root.update_idletasks()
     root.after(0, fixNoButtonLabelsBug)
     root.protocol("WM_DELETE_WINDOW", app.quit)
+    if platform.system() == "Darwin":
+        # Cmd+Q is delivered through Tk's tk::mac::Quit handler, not
+        # WM_DELETE_WINDOW. Without this, Tk's default handler terminates the
+        # process immediately: quit() never runs, the game jar is left patched,
+        # and the launch thread is abandoned (issue #74).
+        root.createcommand("tk::mac::Quit", app.quit)
     icon = None
     try:
         icon = PhotoImage(file="spacehaven-modloader.png")


### PR DESCRIPTION
## Summary
- Register `tk::mac::Quit` so Cmd+Q on macOS routes through the same guarded `quit()` as the window close button, instead of bypassing it via Tk's default Quit handler.
- Mark the background task thread as a daemon so the interpreter can exit once the GUI is gone, instead of lingering as a headless process while waiting on the launched game.

## Why
On macOS, Cmd+Q is delivered through Tk's `tk::mac::Quit` handler rather than `WM_DELETE_WINDOW`, so it bypassed `quit()` entirely. Depending on the Tk build this either terminated the process immediately (skipping `unload()`, leaving `spacehaven.jar` patched) or destroyed the window while the non-daemon launch thread kept the loader alive as a headless process waiting on the game to exit — matching the `ps` output in the issue.

Fixes #74

## Test plan
- [x] All existing unit tests pass (`uv run python -m unittest discover -s tests`)
- [x] `ruff check` passes
- [x] Reproduced the bug with a minimal Tk app (default Quit path kills the process with no cleanup)
- [x] Verified Cmd+Q is correctly blocked while a background task is running ("Cannot quit while a task is running!")
- [x] Verified the patched loader exits cleanly (exit code 0) on Cmd+Q when idle, on macOS