### PR TITLE
Relocate code inject mod instructions

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -17,11 +17,13 @@ to facilitate development.
 If you don't have uv installed, follow the official instructions for your platform at
 https://docs.astral.sh/uv/getting-started/installation/
 
+
 ## Cloning the repository
 
 `git clone` the repository into your Projects folder.
 
 For the remainder of this document, we'll assume the working directory is the root of the repository.
+
 
 ## Installing pyenv
 
@@ -39,6 +41,7 @@ Alternatively, you can manually install python with the uv command:
 ```shell
 uv python install 3.11.9
 ```
+
 
 ## Set up Virtual Environment
 
@@ -59,43 +62,3 @@ uv run python spacehaven-modloader.py
 
 It is possible to avoid activating the virtual environment for future invocations by running the loader with the path
 to the Python interpreter in the virtual environment, e.g. `venv/bin/python` command.
-
-
-## JAR / AspectJ Mod Internals
-
-This section is for authors of code-injection (JAR/AspectJ) mods, not end users. End users should read [README.md](README.md).
-
-### Where the loader writes `config.json`
-
-`config.json` is always resolved as `<gameDir>/config.json`, where `<gameDir>` is the directory of the detected `spacehaven.jar`. The loader never resolves `config.json` relative to a Steam Workshop content folder, even when the mod itself lives in `steamapps/workshop/content/979110/<id>/`.
-
-### `classPath` injection
-
-When a JAR mod is enabled, the loader inserts the JAR's absolute path (with forward slashes) into `config.json` → `classPath`, immediately before `spacehaven.jar`. AspectJ entries (`aspectjweaver-1.9.19.jar`, `aspectj-1.9.19.jar`) are kept at positions 0 and 1. Existing unrelated entries are preserved in their original order.
-
-### `classPath` cleanup
-
-During mod discovery and before each launch, the loader performs a conservative cleanup of `classPath`:
-
-- Entries under known mod roots (local `mods/` and the Steam Workshop content folder) that no longer correspond to an enabled mod are removed.
-- Entries under known mod roots whose file is missing are removed.
-- Exact duplicate entries are deduped.
-- Entries outside known mod roots are left untouched (manual additions are preserved).
-- If `config.json` is missing or `classPath` is not a list, cleanup is skipped.
-
-### Asset resolution for JAR mods
-
-Java mods that need external assets should not assume a fixed `SpaceHaven/mods/<ModName>` layout, because the same mod may also be installed from Workshop. The two supported patterns are:
-
-1. **Bundle assets inside the JAR** and read them via `getResource()` / `getResourceAsStream()`.
-2. **Resolve files relative to the JAR's own location** using `getProtectionDomain().getCodeSource().getLocation()`. Example:
-
-   ```java
-   URL jarUrl = MyMod.class.getProtectionDomain()
-       .getCodeSource()
-       .getLocation();
-   Path modDir = Paths.get(jarUrl.toURI()).getParent();
-   Path config = modDir.resolve("mystuff/config.json");
-   ```
-
-Either pattern works equally well for local and Workshop installs and avoids relying on a global classpath registry.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,45 @@ Running the game from the modloader will not load your cloud credentials correct
 There are two types of mods supported by the modloader. These are XML mods, which are used to create new buildings, and code injection mods that can alter game functionality. Info on both types of mods is below.
 
 ### Code Injection Mods
-These mods use AspectJ (similar to Harmony in C#) to allow you to inject code before, after, and around the game's existing functions, method calls, and field accesses. This functionality makes code injection mods extremely poewrful, but they require programming knowledge (or patience and a willingness to learn) to create. You'll also want a tool that allows you to decompile `spacehaven.jar`. I recommend [JD GUI](https://github.com/java-decompiler/jd-gui) as it seemed to work the best out of the few options I tried. The game's code is not obfuscated, so the decompilation process is relatively painless. 
+These mods use AspectJ (similar to Harmony in C#) to allow you to inject code before, after, and around the game's existing functions, method calls, and field accesses. This functionality makes code injection mods extremely powerful, but they require programming knowledge (or patience and a willingness to learn) to create. You'll also want a tool that allows you to decompile `spacehaven.jar`. I recommend [JD GUI](https://github.com/java-decompiler/jd-gui) as it seemed to work the best out of the few options I tried. The game's code is not obfuscated, so the decompilation process is relatively painless. 
 
 There's a [template repo](https://github.com/Spacehaven-modding-tools/SpaceHavenModTemplate) that you can use as a basis for creating your own code injection mod. The template repo includes instructions on how to set up your dev environment as well as some basic sample mods.
+
+#### Where the loader writes `config.json`
+
+`config.json` is always resolved as `<gameDir>/config.json`, where `<gameDir>` is the directory of the detected `spacehaven.jar`. The loader never resolves `config.json` relative to a Steam Workshop content folder, even when the mod itself lives in `steamapps/workshop/content/979110/<id>/`.
+
+#### `classPath` injection
+
+When a JAR mod is enabled, the loader inserts the JAR's absolute path (with forward slashes) into `config.json` → `classPath`, immediately before `spacehaven.jar`. AspectJ entries (`aspectjweaver-1.9.19.jar`, `aspectj-1.9.19.jar`) are kept at positions 0 and 1. Existing unrelated entries are preserved in their original order.
+
+#### `classPath` cleanup
+
+During mod discovery and before each launch, the loader performs a conservative cleanup of `classPath`:
+
+- Entries under known mod roots (local `mods/` and the Steam Workshop content folder) that no longer correspond to an enabled mod are removed.
+- Entries under known mod roots whose file is missing are removed.
+- Exact duplicate entries are deduped.
+- Entries outside known mod roots are left untouched (manual additions are preserved).
+- If `config.json` is missing or `classPath` is not a list, cleanup is skipped.
+
+#### Asset resolution for JAR mods
+
+Java mods that need external assets should not assume a fixed `SpaceHaven/mods/<ModName>` layout, because the same mod may also be installed from Workshop. The two supported patterns are:
+
+1. **Bundle assets inside the JAR** and read them via `getResource()` / `getResourceAsStream()`.
+2. **Resolve files relative to the JAR's own location** using `getProtectionDomain().getCodeSource().getLocation()`. Example:
+
+   ```java
+   URL jarUrl = MyMod.class.getProtectionDomain()
+       .getCodeSource()
+       .getLocation();
+   Path modDir = Paths.get(jarUrl.toURI()).getParent();
+   Path config = modDir.resolve("mystuff/config.json");
+   ```
+
+Either pattern works equally well for local and Workshop installations and avoids relying on a global classpath registry.
+
 
 ### XML Mods
 
@@ -103,7 +139,7 @@ I recommend prefixing your definition IDs with your Discord user number (e.g. mi
 
 #### Navigating the Library
 
-Since ID numbers are unique they're reasonably easy to follow in a text editor - if you find a definition that references another, simply search for the referenced ID that you're interested in.
+Since ID numbers are unique, they're reasonably easy to follow in a text editor – if you find a definition that references another, simply search for the referenced ID that you're interested in.
 
 To find human-readable names, look for a `tid="###"` attribute and search for that ID in `library/texts`. Or, conversely, find the text in `library/texts` and search for the corresponding ID in `library/haven`.
 


### PR DESCRIPTION
- DEVELOPERS.md holds information for development of the mod loader and is not intended for mod developers.